### PR TITLE
Set Archival URI in resource state from cluster namespace configuration

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -216,6 +216,8 @@ func (r *NamespaceResource) Create(ctx context.Context, req resource.CreateReque
 
 	data.Id = types.StringValue(ns.NamespaceInfo.GetId())
 	data.ActiveClusterName = types.StringValue(ns.GetReplicationConfig().GetActiveClusterName())
+	data.HistoryArchivalUri = types.StringValue(ns.GetConfig().GetHistoryArchivalUri())
+	data.VisibilityArchivalUri = types.StringValue(ns.GetConfig().GetVisibilityArchivalUri())
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -314,7 +316,7 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 
 	data.Id = types.StringValue(ns.NamespaceInfo.GetId())
 	data.ActiveClusterName = types.StringValue(ns.GetReplicationConfig().GetActiveClusterName())
-
+	// TODO: Assign HistoryArchivalURI and VisibilityArchivalURI to the data.
 	tflog.Info(ctx, fmt.Sprintf("The namespace: %s is successfully registered", data.Name))
 	tflog.Trace(ctx, "created a resource")
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -116,7 +116,6 @@ func (r *NamespaceResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "History Archival URI",
 				Computed:            true,
 				Optional:            true,
-				Default:             stringdefault.StaticString(""),
 			},
 			"visibility_archival_state": schema.StringAttribute{
 				MarkdownDescription: "Visibility Archival State",
@@ -128,7 +127,6 @@ func (r *NamespaceResource) Schema(ctx context.Context, req resource.SchemaReque
 				MarkdownDescription: "Visibility Archival URI",
 				Computed:            true,
 				Optional:            true,
-				Default:             stringdefault.StaticString(""),
 			},
 			"is_global_namespace": schema.BoolAttribute{
 				MarkdownDescription: "Namespace is Global",
@@ -316,7 +314,8 @@ func (r *NamespaceResource) Update(ctx context.Context, req resource.UpdateReque
 
 	data.Id = types.StringValue(ns.NamespaceInfo.GetId())
 	data.ActiveClusterName = types.StringValue(ns.GetReplicationConfig().GetActiveClusterName())
-	// TODO: Assign HistoryArchivalURI and VisibilityArchivalURI to the data.
+	data.HistoryArchivalUri = types.StringValue(ns.GetConfig().GetHistoryArchivalUri())
+	data.VisibilityArchivalUri = types.StringValue(ns.GetConfig().GetVisibilityArchivalUri())
 	tflog.Info(ctx, fmt.Sprintf("The namespace: %s is successfully registered", data.Name))
 	tflog.Trace(ctx, "created a resource")
 


### PR DESCRIPTION
## Description

Fixes #54.
* Setting URI values in state following create and update
* Removing empty string as default value for URI attributes

## TODOs
- [x] Generate the docs.
- [x] Run the relevant tests successfully.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
* Added `history_archival_uri` and `visibility_archival_uri` to state from namespace describe config following create/update
* Removed default value of `stringdefault.StaticString("")` for these attributes in favour of implicit null

### Migration Guide
In cases where state drift is already happening due to the original issue, `terraform apply` resulting in change action for the resource will resolve.
