### PR TITLE
Adding test for Namespace Already Exists

### DIFF
--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -1,6 +1,7 @@
 package provider_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -46,6 +47,34 @@ resource "temporal_namespace" "test" {
 					resource.TestCheckResourceAttr("temporal_namespace.test", "name", "test"),
 					resource.TestCheckResourceAttr("temporal_namespace.test", "owner_email", "updated@example.org"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNamespaceAlreadyExsits(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfig + `
+				resource "temporal_namespace" "test1" {
+					name        = "test"
+					description = "This is a test namespace"
+					owner_email = "test@example.org"
+				}`,
+			},
+			// Namespace already exists Error
+			{
+				Config: providerConfig + `
+				resource "temporal_namespace" "test2" {
+					name        = "test"
+					description = "This is a test namespace"
+					owner_email = "test@example.org"
+				}
+				`,
+				ExpectError: regexp.MustCompile("namespace registration failed.*code = AlreadyExists"),
 			},
 		},
 	})


### PR DESCRIPTION
This is resubmission of https://github.com/platacard/terraform-provider-temporal/pull/57 - since the commits were not verified correctly.

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adding test for Namespace Already Exists

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Contribution guidelines](/.github/CODE_OF_CONDUCT.md).

- [ ] Generate the docs.
- [x] Run the relevant tests successfully.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Adding test

### Migration Guide
N/A
<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
