### PR TITLE
Handle Missing Namespace

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -246,7 +246,6 @@ func (r *NamespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		errCode := status.Code(err)
 		if errCode == codes.NotFound {
 			tflog.Warn(ctx, "Namespace not found", map[string]interface{}{"err": err, "namespace": namespace})
-			resp.State.RemoveResource(ctx)
 			return
 		} else {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read Namespace info, got error: %s", err))


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

When a namespace is in the state file, but not in the temporal server, applying the namespace return an error.

Way to reproduce problem:
* In one window, run the server with temporal server start-dev
* In another window run temporal apply. Remove old .terraform* files if exists.
* Stop and restart the server in the firs windw.
* In the second window run temporal apply again. You will get an error/

<!-- Description of the changes introduced by this PR. -->

After the fix, the namespace would be re-added.

Read the [Contribution guidelines](/.github/CODE_OF_CONDUCT.md).

- [ ] Generate the docs.
- [x] Run the relevant tests successfully.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
