### PR TITLE
Fix panics and auth token refresh

### DIFF
--- a/internal/provider/namespace_data_source.go
+++ b/internal/provider/namespace_data_source.go
@@ -179,7 +179,7 @@ func namespaceToNamespaceDataSourceModel(ctx context.Context, ns *workflowservic
 		Id:                      types.StringValue(ns.NamespaceInfo.GetId()),
 		Description:             types.StringValue(ns.NamespaceInfo.GetDescription()),
 		OwnerEmail:              types.StringValue(ns.NamespaceInfo.GetOwnerEmail()),
-		Retention:               types.Int64Value(int64(ns.Config.WorkflowExecutionRetentionTtl.AsDuration().Hours() / 24)),
+		Retention:               types.Int64Value(int64(ns.GetConfig().GetWorkflowExecutionRetentionTtl().AsDuration().Hours() / 24)),
 		ActiveClusterName:       types.StringValue(ns.GetReplicationConfig().GetActiveClusterName()),
 		HistoryArchivalState:    types.StringValue(ns.Config.GetHistoryArchivalState().String()),
 		HistoryArchivalUri:      types.StringValue(ns.Config.GetHistoryArchivalUri()),
@@ -194,6 +194,13 @@ func namespaceToNamespaceDataSourceModel(ctx context.Context, ns *workflowservic
 			return nil, diags
 		}
 		data.Clusters = clustersList
+	} else {
+		emptyList, emptyDiags := types.ListValueFrom(ctx, types.StringType, []string{})
+		diags.Append(emptyDiags...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		data.Clusters = emptyList
 	}
 	return data, diags
 }

--- a/internal/provider/namespace_data_source_nil_test.go
+++ b/internal/provider/namespace_data_source_nil_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestNamespaceDataSourceModel_NilConfig verifies that namespaceToNamespaceDataSourceModel
 // does not panic when ns.Config is nil. Before the fix the function accessed
-// ns.Config.WorkflowExecutionRetentionTtl directly, which panicked
+// ns.Config.WorkflowExecutionRetentionTtl directly, which panicked.
 func TestNamespaceDataSourceModel_NilConfig(t *testing.T) {
 	ctx := context.Background()
 	ns := &workflowservice.DescribeNamespaceResponse{
@@ -34,7 +34,7 @@ func TestNamespaceDataSourceModel_NilConfig(t *testing.T) {
 
 // TestNamespaceDataSourceModel_EmptyClusters verifies that the Clusters field is
 // a typed empty list (not null) when no clusters are configured. A null or
-// zero-value list causes Terraform Framework to detect a perpetual diff
+// zero-value list causes Terraform Framework to detect a perpetual diff.
 func TestNamespaceDataSourceModel_EmptyClusters(t *testing.T) {
 	ctx := context.Background()
 	ns := &workflowservice.DescribeNamespaceResponse{

--- a/internal/provider/namespace_data_source_nil_test.go
+++ b/internal/provider/namespace_data_source_nil_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	namespacev1 "go.temporal.io/api/namespace/v1"
+	replicationv1 "go.temporal.io/api/replication/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+)
+
+// TestNamespaceDataSourceModel_NilConfig verifies that namespaceToNamespaceDataSourceModel
+// does not panic when ns.Config is nil. Before the fix the function accessed
+// ns.Config.WorkflowExecutionRetentionTtl directly, which panicked
+func TestNamespaceDataSourceModel_NilConfig(t *testing.T) {
+	ctx := context.Background()
+	ns := &workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo:     &namespacev1.NamespaceInfo{Name: "test-ns"},
+		Config:            nil,
+		ReplicationConfig: &replicationv1.NamespaceReplicationConfig{},
+	}
+
+	model, diags := namespaceToNamespaceDataSourceModel(ctx, ns)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if model == nil {
+		t.Fatal("expected non-nil model")
+	}
+	if model.Retention.ValueInt64() != 0 {
+		t.Errorf("expected Retention 0 for nil Config, got %d", model.Retention.ValueInt64())
+	}
+}
+
+// TestNamespaceDataSourceModel_EmptyClusters verifies that the Clusters field is
+// a typed empty list (not null) when no clusters are configured. A null or
+// zero-value list causes Terraform Framework to detect a perpetual diff
+func TestNamespaceDataSourceModel_EmptyClusters(t *testing.T) {
+	ctx := context.Background()
+	ns := &workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo:     &namespacev1.NamespaceInfo{Name: "test-ns"},
+		Config:            &namespacev1.NamespaceConfig{},
+		ReplicationConfig: &replicationv1.NamespaceReplicationConfig{},
+	}
+
+	model, diags := namespaceToNamespaceDataSourceModel(ctx, ns)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if model.Clusters.IsNull() {
+		t.Error("Clusters must be a typed empty list, not null — would cause perpetual state drift")
+	}
+	if len(model.Clusters.Elements()) != 0 {
+		t.Errorf("expected 0 cluster elements, got %d", len(model.Clusters.Elements()))
+	}
+}

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -493,6 +493,13 @@ func updateModelFromSpec(ctx context.Context, data *NamespaceResourceModel, ns *
 			return diags
 		}
 		data.Clusters = clustersList
+	} else {
+		emptyList, emptyDiags := types.ListValueFrom(ctx, types.StringType, []string{})
+		diags.Append(emptyDiags...)
+		if diags.HasError() {
+			return diags
+		}
+		data.Clusters = emptyList
 	}
 	return diags
 }

--- a/internal/provider/namespace_resource_nil_test.go
+++ b/internal/provider/namespace_resource_nil_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	namespacev1 "go.temporal.io/api/namespace/v1"
+	replicationv1 "go.temporal.io/api/replication/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+)
+
+// TestUpdateModelFromSpec_EmptyClusters verifies that updateModelFromSpec sets
+// Clusters to a typed empty list (not a zero-value types.List{}) when the
+// namespace has no replication clusters. A zero-value list has no element type
+// and causes Terraform Framework to detect a perpetual diff
+func TestUpdateModelFromSpec_EmptyClusters(t *testing.T) {
+	ctx := context.Background()
+	data := &NamespaceResourceModel{}
+	ns := &workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo:     &namespacev1.NamespaceInfo{},
+		Config:            &namespacev1.NamespaceConfig{},
+		ReplicationConfig: &replicationv1.NamespaceReplicationConfig{},
+	}
+
+	diags := updateModelFromSpec(ctx, data, ns)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if data.Clusters.IsNull() {
+		t.Error("Clusters must not be null — would cause perpetual state drift")
+	}
+	if data.Clusters.IsUnknown() {
+		t.Error("Clusters must not be unknown")
+	}
+	if len(data.Clusters.Elements()) != 0 {
+		t.Errorf("expected 0 cluster elements, got %d", len(data.Clusters.Elements()))
+	}
+}
+
+// TestUpdateModelFromSpec_WithClusters verifies that updateModelFromSpec correctly
+// populates Clusters when the namespace has replication clusters.
+func TestUpdateModelFromSpec_WithClusters(t *testing.T) {
+	ctx := context.Background()
+	data := &NamespaceResourceModel{}
+	ns := &workflowservice.DescribeNamespaceResponse{
+		NamespaceInfo: &namespacev1.NamespaceInfo{},
+		Config:        &namespacev1.NamespaceConfig{},
+		ReplicationConfig: &replicationv1.NamespaceReplicationConfig{
+			ActiveClusterName: "active",
+			Clusters: []*replicationv1.ClusterReplicationConfig{
+				{ClusterName: "active"},
+				{ClusterName: "standby"},
+			},
+		},
+	}
+
+	diags := updateModelFromSpec(ctx, data, ns)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if len(data.Clusters.Elements()) != 2 {
+		t.Errorf("expected 2 cluster elements, got %d", len(data.Clusters.Elements()))
+	}
+}

--- a/internal/provider/namespace_resource_nil_test.go
+++ b/internal/provider/namespace_resource_nil_test.go
@@ -12,7 +12,7 @@ import (
 // TestUpdateModelFromSpec_EmptyClusters verifies that updateModelFromSpec sets
 // Clusters to a typed empty list (not a zero-value types.List{}) when the
 // namespace has no replication clusters. A zero-value list has no element type
-// and causes Terraform Framework to detect a perpetual diff
+// and causes Terraform Framework to detect a perpetual diff.
 func TestUpdateModelFromSpec_EmptyClusters(t *testing.T) {
 	ctx := context.Background()
 	data := &NamespaceResourceModel{}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc"
 	grpcCreds "google.golang.org/grpc/credentials"
@@ -349,27 +348,23 @@ func New(version string) func() provider.Provider {
 	}
 }
 
-// GetToken retrieves an OAuth token using client credentials.
-func GetToken(clientID, clientSecret, tokenURL, audience string) (*oauth2.Token, error) {
-	clientCredentials := clientcredentials.Config{
+// CreateAuthenticatedClient creates a gRPC client with OAuth authentication.
+// It uses a TokenSource so the token is automatically refreshed when it expires.
+func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL string, scopes []string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
+	cfg := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     tokenURL,
-		Scopes:       strings.Split(audience, ","),
+		Scopes:       scopes,
 	}
+	ts := cfg.TokenSource(context.Background())
 
-	token, err := clientCredentials.Token(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve token: %v", err)
-	}
-
-	return token, nil
-}
-
-// CreateAuthenticatedClient creates a gRPC client with OAuth authentication.
-func CreateAuthenticatedClient(endpoint string, token *oauth2.Token, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
 	return grpc.NewClient(endpoint, grpc.WithTransportCredentials(credentials), grpc.WithUnaryInterceptor(
 		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			token, err := ts.Token()
+			if err != nil {
+				return fmt.Errorf("failed to retrieve OAuth token: %w", err)
+			}
 			newCtx := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token.AccessToken)
 			return invoker(newCtx, method, req, reply, cc, opts...)
 		},
@@ -419,12 +414,7 @@ func CreateGRPCClient(clientID, clientSecret, tokenURL, audience, endpoint strin
 	}
 
 	if clientID != "" {
-		token, err := GetToken(clientID, clientSecret, tokenURL, audience)
-		if err != nil {
-			return nil, err
-		}
-
-		return CreateAuthenticatedClient(endpoint, token, credentials)
+		return CreateAuthenticatedClient(endpoint, clientID, clientSecret, tokenURL, strings.Split(audience, ","), credentials)
 	} else if useTLS {
 		return CreateSecureClient(endpoint, credentials)
 	}

--- a/internal/provider/provider_oauth_test.go
+++ b/internal/provider/provider_oauth_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	grpcInsec "google.golang.org/grpc/credentials/insecure"
+)
+
+type mockTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func newMockTokenServer(t *testing.T, calls *int, expiresIn int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*calls++
+		w.Header().Set("Content-Type", "application/json")
+		resp := mockTokenResponse{
+			AccessToken: fmt.Sprintf("token-%d", *calls),
+			TokenType:   "Bearer",
+			ExpiresIn:   expiresIn,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// TestCreateAuthenticatedClient_LazyTokenFetch verifies that CreateAuthenticatedClient
+// does not fetch an OAuth2 token at construction time. The token must only be
+// fetched when an actual gRPC call is made
+func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
+	calls := 0
+	srv := newMockTokenServer(t, &calls, 3600)
+	defer srv.Close()
+
+	conn, err := CreateAuthenticatedClient(
+		"localhost:9999",
+		"client-id",
+		"client-secret",
+		srv.URL+"/token",
+		[]string{"scope"},
+		grpcInsec.NewCredentials(),
+	)
+	if err != nil {
+		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
+	}
+	defer conn.Close()
+
+	if calls != 0 {
+		t.Errorf("expected 0 token fetches at client creation, got %d — TokenSource must be lazy", calls)
+	}
+}
+
+// TestCreateAuthenticatedClient_TokenServerUnreachable verifies that
+// CreateAuthenticatedClient does not fail when the token server is unreachable.
+// Before the fix, GetToken() was called eagerly at startup and would have
+// returned an error here
+func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
+	conn, err := CreateAuthenticatedClient(
+		"localhost:9999",
+		"client-id",
+		"client-secret",
+		"http://127.0.0.1:0/token",
+		[]string{"scope"},
+		grpcInsec.NewCredentials(),
+	)
+	if err != nil {
+		t.Fatalf("CreateAuthenticatedClient must not fail at construction when token server is unreachable: %v", err)
+	}
+	defer conn.Close()
+}
+
+// TestCreateAuthenticatedClient_RefreshesExpiredToken verifies that the token
+// server is not called at construction even when tokens would expire immediately
+// (expires_in=0). The old code fetched the token once at startup; the new code
+// uses a TokenSource that refreshes lazily on each gRPC call
+func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
+	calls := 0
+	srv := newMockTokenServer(t, &calls, 0) // expires_in=0 = token expires immediately
+	defer srv.Close()
+
+	conn, err := CreateAuthenticatedClient(
+		"localhost:9999",
+		"client-id",
+		"client-secret",
+		srv.URL+"/token",
+		[]string{"scope"},
+		grpcInsec.NewCredentials(),
+	)
+	if err != nil {
+		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
+	}
+	defer conn.Close()
+
+	if calls != 0 {
+		t.Errorf("expected 0 calls at construction, got %d", calls)
+	}
+}

--- a/internal/provider/provider_oauth_test.go
+++ b/internal/provider/provider_oauth_test.go
@@ -32,7 +32,7 @@ func newMockTokenServer(t *testing.T, calls *int, expiresIn int) *httptest.Serve
 
 // TestCreateAuthenticatedClient_LazyTokenFetch verifies that CreateAuthenticatedClient
 // does not fetch an OAuth2 token at construction time. The token must only be
-// fetched when an actual gRPC call is made
+// fetched when an actual gRPC call is made.
 func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 	calls := 0
 	srv := newMockTokenServer(t, &calls, 3600)
@@ -49,7 +49,7 @@ func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	if calls != 0 {
 		t.Errorf("expected 0 token fetches at client creation, got %d — TokenSource must be lazy", calls)
@@ -59,7 +59,7 @@ func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 // TestCreateAuthenticatedClient_TokenServerUnreachable verifies that
 // CreateAuthenticatedClient does not fail when the token server is unreachable.
 // Before the fix, GetToken() was called eagerly at startup and would have
-// returned an error here
+// returned an error here.
 func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
 	conn, err := CreateAuthenticatedClient(
 		"localhost:9999",
@@ -72,13 +72,13 @@ func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient must not fail at construction when token server is unreachable: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 }
 
 // TestCreateAuthenticatedClient_RefreshesExpiredToken verifies that the token
 // server is not called at construction even when tokens would expire immediately
 // (expires_in=0). The old code fetched the token once at startup; the new code
-// uses a TokenSource that refreshes lazily on each gRPC call
+// uses a TokenSource that refreshes lazily on each gRPC call.
 func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 	calls := 0
 	srv := newMockTokenServer(t, &calls, 0) // expires_in=0 = token expires immediately
@@ -95,7 +95,7 @@ func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	if calls != 0 {
 		t.Errorf("expected 0 calls at construction, got %d", calls)

--- a/internal/provider/schedule_resource.go
+++ b/internal/provider/schedule_resource.go
@@ -530,18 +530,23 @@ func (r *ScheduleResource) Read(ctx context.Context, req resource.ReadRequest, r
 		if describeResp.Schedule.Action != nil {
 			data.Action = convertScheduleAction(describeResp.Schedule.Action)
 		}
+
+		data.State = &ScheduleStateModel{
+			Paused:           types.BoolValue(describeResp.Schedule.State.GetPaused()),
+			LimitedActions:   types.BoolValue(describeResp.Schedule.State.GetLimitedActions()),
+			RemainingActions: types.Int64Value(describeResp.Schedule.State.GetRemainingActions()),
+			Notes:            types.StringValue(describeResp.Schedule.State.GetNotes()),
+		}
+
+		if describeResp.Schedule.Policies != nil {
+			data.Policy = &SchedulePolicyModel{
+				Overlap:        types.StringValue(describeResp.Schedule.Policies.OverlapPolicy.String()),
+				CatchupWindow:  types.StringValue(formatDurationCanonical(describeResp.Schedule.Policies.CatchupWindow)),
+				PauseOnFailure: types.BoolValue(describeResp.Schedule.Policies.GetPauseOnFailure()),
+			}
+		}
 	}
-	data.State = &ScheduleStateModel{
-		Paused:           types.BoolValue(describeResp.Schedule.State.GetPaused()),
-		LimitedActions:   types.BoolValue(describeResp.Schedule.State.GetLimitedActions()),
-		RemainingActions: types.Int64Value(describeResp.Schedule.State.GetRemainingActions()),
-		Notes:            types.StringValue(describeResp.Schedule.State.GetNotes()),
-	}
-	data.Policy = &SchedulePolicyModel{
-		Overlap:        types.StringValue(describeResp.Schedule.Policies.OverlapPolicy.String()),
-		CatchupWindow:  types.StringValue(formatDurationCanonical(describeResp.Schedule.Policies.CatchupWindow)),
-		PauseOnFailure: types.BoolValue(describeResp.Schedule.Policies.GetPauseOnFailure()),
-	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 }
@@ -957,7 +962,7 @@ func convertScheduleSpec(spec *schedulev1.ScheduleSpec) *ScheduleSpecModel {
 	}
 
 	if spec.Jitter != nil {
-		tfSpec.Jitter = types.StringValue(spec.Jitter.String())
+		tfSpec.Jitter = types.StringValue(formatDurationCanonical(spec.Jitter))
 	}
 
 	return tfSpec

--- a/internal/provider/schedule_resource_nil_test.go
+++ b/internal/provider/schedule_resource_nil_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"testing"
+	"time"
+
+	schedulev1 "go.temporal.io/api/schedule/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// TestConvertScheduleSpec_NilSpec verifies that convertScheduleSpec returns nil
+// without panicking when called with a nil spec
+func TestConvertScheduleSpec_NilSpec(t *testing.T) {
+	model := convertScheduleSpec(nil)
+	if model != nil {
+		t.Errorf("expected nil for nil input, got %+v", model)
+	}
+}
+
+// TestConvertScheduleSpec_NilJitter verifies that an absent Jitter field results
+// in a null Terraform value rather than a panic
+func TestConvertScheduleSpec_NilJitter(t *testing.T) {
+	spec := &schedulev1.ScheduleSpec{TimezoneName: "UTC"}
+	model := convertScheduleSpec(spec)
+	if model == nil {
+		t.Fatal("expected non-nil model")
+	}
+	if !model.Jitter.IsNull() {
+		t.Errorf("expected Jitter to be null when not set, got %q", model.Jitter.ValueString())
+	}
+}
+
+// TestConvertScheduleSpec_JitterRoundtrip verifies that the Jitter field is
+// serialized as a human-readable duration string ("5m") rather than the protobuf
+// text format ("seconds:300 nanos:0"), which caused an infinite plan/apply
+func TestConvertScheduleSpec_JitterRoundtrip(t *testing.T) {
+	spec := &schedulev1.ScheduleSpec{
+		Jitter: durationpb.New(5 * time.Minute),
+	}
+
+	model := convertScheduleSpec(spec)
+	if model == nil {
+		t.Fatal("expected non-nil ScheduleSpecModel")
+	}
+
+	got := model.Jitter.ValueString()
+	want := "5m"
+	if got != want {
+		t.Errorf("Jitter: got %q, want %q — would cause infinite plan/apply drift", got, want)
+	}
+}
+
+// TestConvertFromTemporalSchedule_NilSchedule verifies that ConvertFromTemporalSchedule
+// returns an error for a nil schedule without panicking
+func TestConvertFromTemporalSchedule_NilSchedule(t *testing.T) {
+	_, err := ConvertFromTemporalSchedule("id", "ns", nil)
+	if err == nil {
+		t.Error("expected error for nil schedule, got nil")
+	}
+}
+
+// TestConvertFromTemporalSchedule_NilSpecAndAction verifies that a schedule with
+// nil Spec and Action fields does not panic and leaves the model fields nil
+func TestConvertFromTemporalSchedule_NilSpecAndAction(t *testing.T) {
+	sched := &schedulev1.Schedule{}
+	model, err := ConvertFromTemporalSchedule("id", "default", sched)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if model.Spec != nil {
+		t.Error("expected Spec to be nil when Schedule.Spec is nil")
+	}
+	if model.Action != nil {
+		t.Error("expected Action to be nil when Schedule.Action is nil")
+	}
+}

--- a/internal/provider/schedule_resource_nil_test.go
+++ b/internal/provider/schedule_resource_nil_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestConvertScheduleSpec_NilSpec verifies that convertScheduleSpec returns nil
-// without panicking when called with a nil spec
+// without panicking when called with a nil spec.
 func TestConvertScheduleSpec_NilSpec(t *testing.T) {
 	model := convertScheduleSpec(nil)
 	if model != nil {
@@ -18,7 +18,7 @@ func TestConvertScheduleSpec_NilSpec(t *testing.T) {
 }
 
 // TestConvertScheduleSpec_NilJitter verifies that an absent Jitter field results
-// in a null Terraform value rather than a panic
+// in a null Terraform value rather than a panic.
 func TestConvertScheduleSpec_NilJitter(t *testing.T) {
 	spec := &schedulev1.ScheduleSpec{TimezoneName: "UTC"}
 	model := convertScheduleSpec(spec)
@@ -32,7 +32,7 @@ func TestConvertScheduleSpec_NilJitter(t *testing.T) {
 
 // TestConvertScheduleSpec_JitterRoundtrip verifies that the Jitter field is
 // serialized as a human-readable duration string ("5m") rather than the protobuf
-// text format ("seconds:300 nanos:0"), which caused an infinite plan/apply
+// text format ("seconds:300 nanos:0"), which caused an infinite plan/apply.
 func TestConvertScheduleSpec_JitterRoundtrip(t *testing.T) {
 	spec := &schedulev1.ScheduleSpec{
 		Jitter: durationpb.New(5 * time.Minute),
@@ -51,7 +51,7 @@ func TestConvertScheduleSpec_JitterRoundtrip(t *testing.T) {
 }
 
 // TestConvertFromTemporalSchedule_NilSchedule verifies that ConvertFromTemporalSchedule
-// returns an error for a nil schedule without panicking
+// returns an error for a nil schedule without panicking.
 func TestConvertFromTemporalSchedule_NilSchedule(t *testing.T) {
 	_, err := ConvertFromTemporalSchedule("id", "ns", nil)
 	if err == nil {
@@ -60,7 +60,7 @@ func TestConvertFromTemporalSchedule_NilSchedule(t *testing.T) {
 }
 
 // TestConvertFromTemporalSchedule_NilSpecAndAction verifies that a schedule with
-// nil Spec and Action fields does not panic and leaves the model fields nil
+// nil Spec and Action fields does not panic and leaves the model fields nil.
 func TestConvertFromTemporalSchedule_NilSpecAndAction(t *testing.T) {
 	sched := &schedulev1.Schedule{}
 	model, err := ConvertFromTemporalSchedule("id", "default", sched)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR fixes four critical bugs found during code review and resolves a dependency version conflict that prevented the provider from compiling and lint

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Contribution guidelines](/.github/CODE_OF_CONDUCT.md).

- [x] Generate the docs - No needed.
- [x] Run the relevant tests successfully.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide. - No needed 

## Release Notes (draft)

Fixed four critical bugs: nil pointer panics in `Schedule.Read()` and namespace data source, perpetual state drift caused by incorrect Jitter serialization and uninitialized Clusters list, and OAuth2 token expiry during long-running operations. Updated HashiCorp plugin dependencies to resolve a compile-time interface compatibility error introduced by `terraform-plugin-go v0.31.0`.
