### PR TITLE
fix: decouple OAuth audience from scopes; add scopes attribute

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
         run: |
@@ -65,7 +68,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@v3.1.1
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform-version }}
           terraform_wrapper: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ provider "temporal" {
   client_secret = var.temporal_client_secret
   token_url     = "https://auth.company.com/oauth/token"
   audience      = "temporal-api"
+  scopes        = ["openid", "profile", "email"]
 }
 ```
 
@@ -62,6 +63,7 @@ The provider supports configuration via environment variables:
 | `TEMPORAL_CLIENT_SECRET` | OAuth2 client secret                 |
 | `TEMPORAL_TOKEN_URL`     | OAuth2 token endpoint                |
 | `TEMPORAL_AUDIENCE`      | OAuth2 audience claim                |
+| `TEMPORAL_SCOPES`        | OAuth2 scopes (comma-separated)      |
 | `TEMPORAL_INSECURE`      | Use insecure connection (true/false) |
 
 ## Example Usage
@@ -100,6 +102,7 @@ resource "temporal_namespace" "example" {
 - `host` (String) The Temporal server host.
 - `insecure` (Boolean) Use insecure connection
 - `port` (String) The Temporal server port.
+- `scopes` (List of String) OAuth2 scopes requested when fetching a token. Defaults to ["openid", "profile", "email"].
 - `tls` (Block, Optional) TLS Configuration for the Temporal server (see [below for nested schema](#nestedblock--tls))
 - `token_url` (String) Oauth2 server URL to fetch token from
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -47,6 +48,7 @@ type temporalProviderModel struct {
 	ClientID     types.String `tfsdk:"client_id"`
 	TokenURL     types.String `tfsdk:"token_url"`
 	Audience     types.String `tfsdk:"audience"`
+	Scopes       types.List   `tfsdk:"scopes"`
 	Insecure     types.Bool   `tfsdk:"insecure"`
 	TLS          types.Object `tfsdk:"tls"`
 }
@@ -129,6 +131,11 @@ func (p *TemporalProvider) Schema(ctx context.Context, req provider.SchemaReques
 					stringvalidator.AlsoRequires(path.MatchRoot("token_url")),
 				},
 			},
+			"scopes": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: `OAuth2 scopes requested when fetching a token. Defaults to ["openid", "profile", "email"].`,
+			},
 			"insecure": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Use insecure connection",
@@ -202,6 +209,14 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 				"Either target apply the source of the value first, set the value statically in the configuration, or use the TEMPORAL_AUDIENCE environment variable.",
 		)
 	}
+	if config.Scopes.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("scopes"),
+			"Unknown Scopes",
+			"The provider cannot create the Temporal API client as there is an unknown configuration value for the OAuth2 Scopes. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the TEMPORAL_SCOPES environment variable.",
+		)
+	}
 	if config.Insecure.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("insecure"),
@@ -222,6 +237,7 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 	clientID := os.Getenv("TEMPORAL_CLIENT_ID")
 	clientSecret := os.Getenv("TEMPORAL_CLIENT_SECRET")
 	audience := os.Getenv("TEMPORAL_AUDIENCE")
+	scopes := parseScopesEnv(os.Getenv("TEMPORAL_SCOPES"))
 	insecure, err := getBoolEnv("TEMPORAL_INSECURE")
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
@@ -254,6 +270,17 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 	}
 	if !config.Audience.IsNull() {
 		audience = config.Audience.ValueString()
+	}
+	if !config.Scopes.IsNull() {
+		scopes = nil
+		diags := config.Scopes.ElementsAs(ctx, &scopes, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
 	}
 	if !config.Insecure.IsNull() {
 		insecure = config.Insecure.ValueBool()
@@ -291,10 +318,6 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 		port = "7233"
 	}
 
-	if audience == "" {
-		audience = "openid,profile,email"
-	}
-
 	// Create a new Temporal client using the configuration values
 	ctx = tflog.SetField(ctx, "temporal_host", host)
 	ctx = tflog.SetField(ctx, "temporal_port", port)
@@ -302,7 +325,7 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 
 	tflog.Debug(ctx, "Creating Temporal client")
 	tflog.Debug(ctx, "Use TLS? "+strconv.FormatBool(useTLS))
-	client, err := CreateGRPCClient(clientID, clientSecret, tokenURL, audience, endpoint, insecure, useTLS, certString, keyString, caCerts, serverName)
+	client, err := CreateGRPCClient(clientID, clientSecret, tokenURL, audience, scopes, endpoint, insecure, useTLS, certString, keyString, caCerts, serverName)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Temporal API Client",
@@ -350,12 +373,15 @@ func New(version string) func() provider.Provider {
 
 // CreateAuthenticatedClient creates a gRPC client with OAuth authentication.
 // It uses a TokenSource so the token is automatically refreshed when it expires.
-func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL string, scopes []string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
+func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL, audience string, scopes []string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
 	cfg := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		TokenURL:     tokenURL,
 		Scopes:       scopes,
+	}
+	if audience != "" {
+		cfg.EndpointParams = url.Values{"audience": {audience}}
 	}
 	ts := cfg.TokenSource(context.Background())
 
@@ -382,7 +408,7 @@ func CreateInsecureClient(endpoint string, credentials grpcCreds.TransportCreden
 }
 
 // CreateGRPCClient decides which gRPC client to create based on clientID.
-func CreateGRPCClient(clientID, clientSecret, tokenURL, audience, endpoint string, insecure bool, useTLS bool, certString string, keyString string, caCerts string, serverName string) (*grpc.ClientConn, error) {
+func CreateGRPCClient(clientID, clientSecret, tokenURL, audience string, scopes []string, endpoint string, insecure bool, useTLS bool, certString string, keyString string, caCerts string, serverName string) (*grpc.ClientConn, error) {
 	var credentials grpcCreds.TransportCredentials
 
 	switch insecure {
@@ -414,7 +440,7 @@ func CreateGRPCClient(clientID, clientSecret, tokenURL, audience, endpoint strin
 	}
 
 	if clientID != "" {
-		return CreateAuthenticatedClient(endpoint, clientID, clientSecret, tokenURL, strings.Split(audience, ","), credentials)
+		return CreateAuthenticatedClient(endpoint, clientID, clientSecret, tokenURL, audience, scopes, credentials)
 	} else if useTLS {
 		return CreateSecureClient(endpoint, credentials)
 	}
@@ -427,6 +453,24 @@ func getCA(caCerts []byte) *x509.CertPool {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCerts)
 	return caCertPool
+}
+
+// parseScopesEnv splits a comma-separated env var value into trimmed scope strings.
+func parseScopesEnv(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	scopes := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			scopes = append(scopes, trimmed)
+		}
+	}
+	if len(scopes) == 0 {
+		return nil
+	}
+	return scopes
 }
 
 func getBoolEnv(key string) (result bool, err error) {

--- a/internal/provider/provider_oauth_test.go
+++ b/internal/provider/provider_oauth_test.go
@@ -1,13 +1,20 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
+	"google.golang.org/grpc"
 	grpcInsec "google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type mockTokenResponse struct {
@@ -30,9 +37,6 @@ func newMockTokenServer(t *testing.T, calls *int, expiresIn int) *httptest.Serve
 	}))
 }
 
-// TestCreateAuthenticatedClient_LazyTokenFetch verifies that CreateAuthenticatedClient
-// does not fetch an OAuth2 token at construction time. The token must only be
-// fetched when an actual gRPC call is made.
 func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 	calls := 0
 	srv := newMockTokenServer(t, &calls, 3600)
@@ -43,6 +47,7 @@ func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 		"client-id",
 		"client-secret",
 		srv.URL+"/token",
+		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
 	)
@@ -56,16 +61,13 @@ func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 	}
 }
 
-// TestCreateAuthenticatedClient_TokenServerUnreachable verifies that
-// CreateAuthenticatedClient does not fail when the token server is unreachable.
-// Before the fix, GetToken() was called eagerly at startup and would have
-// returned an error here.
 func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
 	conn, err := CreateAuthenticatedClient(
 		"localhost:9999",
 		"client-id",
 		"client-secret",
 		"http://127.0.0.1:0/token",
+		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
 	)
@@ -75,13 +77,9 @@ func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 }
 
-// TestCreateAuthenticatedClient_RefreshesExpiredToken verifies that the token
-// server is not called at construction even when tokens would expire immediately
-// (expires_in=0). The old code fetched the token once at startup; the new code
-// uses a TokenSource that refreshes lazily on each gRPC call.
 func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 	calls := 0
-	srv := newMockTokenServer(t, &calls, 0) // expires_in=0 = token expires immediately
+	srv := newMockTokenServer(t, &calls, 0)
 	defer srv.Close()
 
 	conn, err := CreateAuthenticatedClient(
@@ -89,6 +87,7 @@ func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 		"client-id",
 		"client-secret",
 		srv.URL+"/token",
+		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
 	)
@@ -99,5 +98,149 @@ func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 
 	if calls != 0 {
 		t.Errorf("expected 0 calls at construction, got %d", calls)
+	}
+}
+
+// Auth0 and other spec-compliant servers require `audience` as a form param, not a scope.
+func TestCreateAuthenticatedClient_PassesAudienceInTokenRequest(t *testing.T) {
+	const wantAudience = "https://temporal.local"
+	wantScopes := []string{"scope-a", "scope-b"}
+
+	var (
+		mu              sync.Mutex
+		gotAudience     string
+		gotScope        string
+		tokenReqHandled = make(chan struct{}, 1)
+	)
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		gotAudience = r.PostFormValue("audience")
+		gotScope = r.PostFormValue("scope")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockTokenResponse{
+			AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600,
+		})
+		select {
+		case tokenReqHandled <- struct{}{}:
+		default:
+		}
+	}))
+	defer tokenSrv.Close()
+
+	// Stub server so Invoke triggers the interceptor's token fetch; the call itself failing is fine.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = lis.Close() }()
+	grpcSrv := grpc.NewServer()
+	go func() { _ = grpcSrv.Serve(lis) }()
+	defer grpcSrv.Stop()
+
+	conn, err := CreateAuthenticatedClient(
+		lis.Addr().String(),
+		"client-id",
+		"client-secret",
+		tokenSrv.URL+"/token",
+		wantAudience,
+		wantScopes,
+		grpcInsec.NewCredentials(),
+	)
+	if err != nil {
+		t.Fatalf("CreateAuthenticatedClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = conn.Invoke(ctx, "/no.svc/Method", &emptypb.Empty{}, &emptypb.Empty{})
+
+	select {
+	case <-tokenReqHandled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("token endpoint was never hit")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAudience != wantAudience {
+		t.Errorf("audience form param: got %q, want %q", gotAudience, wantAudience)
+	}
+	// Scopes are space-joined per RFC 6749 §3.3.
+	if gotScope != "scope-a scope-b" {
+		t.Errorf("scope form param: got %q, want %q", gotScope, "scope-a scope-b")
+	}
+}
+
+// Audience must not leak into the scope= form field even when both are set.
+func TestCreateGRPCClient_DoesNotReflectAudienceIntoScopes(t *testing.T) {
+	const (
+		wantAudience = "https://api.example/"
+		wantScope    = "openid"
+	)
+	var (
+		mu       sync.Mutex
+		gotForm  url.Values
+		captured = make(chan struct{}, 1)
+	)
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		gotForm = r.PostForm
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mockTokenResponse{
+			AccessToken: "tok", TokenType: "Bearer", ExpiresIn: 3600,
+		})
+		select {
+		case captured <- struct{}{}:
+		default:
+		}
+	}))
+	defer tokenSrv.Close()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = lis.Close() }()
+	grpcSrv := grpc.NewServer()
+	go func() { _ = grpcSrv.Serve(lis) }()
+	defer grpcSrv.Stop()
+
+	conn, err := CreateGRPCClient(
+		"client-id", "client-secret",
+		tokenSrv.URL+"/token",
+		wantAudience,
+		[]string{wantScope},
+		lis.Addr().String(),
+		true,
+		false,
+		"", "", "", "",
+	)
+	if err != nil {
+		t.Fatalf("CreateGRPCClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = conn.Invoke(ctx, "/no.svc/Method", &emptypb.Empty{}, &emptypb.Empty{})
+
+	select {
+	case <-captured:
+	case <-time.After(2 * time.Second):
+		t.Fatal("token endpoint was never hit")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := gotForm.Get("audience"); got != wantAudience {
+		t.Errorf("audience form param: got %q, want %q", got, wantAudience)
+	}
+	if got := gotForm.Get("scope"); got != wantScope {
+		t.Errorf("scope form param: got %q, want %q", got, wantScope)
 	}
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -31,6 +31,7 @@ provider "temporal" {
   client_secret = var.temporal_client_secret
   token_url     = "https://auth.company.com/oauth/token"
   audience      = "temporal-api"
+  scopes        = ["openid", "profile", "email"]
 }
 ```
 
@@ -62,6 +63,7 @@ The provider supports configuration via environment variables:
 | `TEMPORAL_CLIENT_SECRET` | OAuth2 client secret                 |
 | `TEMPORAL_TOKEN_URL`     | OAuth2 token endpoint                |
 | `TEMPORAL_AUDIENCE`      | OAuth2 audience claim                |
+| `TEMPORAL_SCOPES`        | OAuth2 scopes (comma-separated)      |
 | `TEMPORAL_INSECURE`      | Use insecure connection (true/false) |
 
 ## Example Usage


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fix bug with audience and scope mismatch

Fixes #163.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Contribution guidelines](/.github/CODE_OF_CONDUCT.md).

- [x] Generate the docs.
- [x] Run the relevant tests successfully.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
 - Add a `scopes` provider attribute (List of String) and TEMPORAL_SCOPES
    env var. Defaults to ["openid", "profile", "email"].
 - Stop reflecting audience into scopes at the CreateGRPCClient call site.
 