### PR TITLE
feat: add grpc_metadata provider attribute for static gRPC headers

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -51,6 +51,7 @@ type temporalProviderModel struct {
 	Scopes       types.List   `tfsdk:"scopes"`
 	Insecure     types.Bool   `tfsdk:"insecure"`
 	TLS          types.Object `tfsdk:"tls"`
+	GrpcMetadata types.Map    `tfsdk:"grpc_metadata"`
 }
 
 // Metadata assigns the provider's name and version.
@@ -140,6 +141,12 @@ func (p *TemporalProvider) Schema(ctx context.Context, req provider.SchemaReques
 				Optional:    true,
 				Description: "Use insecure connection",
 			},
+			"grpc_metadata": schema.MapAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Static gRPC metadata appended to every outgoing call (case-insensitive keys, string values). Useful for reverse-proxy authentication that lives at the HTTP/2 header layer rather than the OAuth Bearer layer — for example Cloudflare Access service tokens (`cf-access-client-id` / `cf-access-client-secret`), Tailscale Funnel, or AWS WAF custom rules. Marked sensitive because credentials are common values; the map is also overrideable via `TEMPORAL_GRPC_METADATA` (comma-separated `k=v` pairs).",
+			},
 		},
 	}
 }
@@ -225,6 +232,14 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 				"Either target apply the source of the value first, set the value statically in the configuration, or use the TEMPORAL_INSECURE environment variable.",
 		)
 	}
+	if config.GrpcMetadata.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("grpc_metadata"),
+			"Unknown gRPC Metadata",
+			"The provider cannot create the Temporal API client as there is an unknown configuration value for the gRPC metadata map. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the TEMPORAL_GRPC_METADATA environment variable.",
+		)
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -238,6 +253,7 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 	clientSecret := os.Getenv("TEMPORAL_CLIENT_SECRET")
 	audience := os.Getenv("TEMPORAL_AUDIENCE")
 	scopes := parseScopesEnv(os.Getenv("TEMPORAL_SCOPES"))
+	grpcMetadata := parseGrpcMetadataEnv(os.Getenv("TEMPORAL_GRPC_METADATA"))
 	insecure, err := getBoolEnv("TEMPORAL_INSECURE")
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
@@ -282,6 +298,14 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 	if len(scopes) == 0 {
 		scopes = []string{"openid", "profile", "email"}
 	}
+	if !config.GrpcMetadata.IsNull() {
+		grpcMetadata = map[string]string{}
+		diags := config.GrpcMetadata.ElementsAs(ctx, &grpcMetadata, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
 	if !config.Insecure.IsNull() {
 		insecure = config.Insecure.ValueBool()
 	}
@@ -325,7 +349,7 @@ func (p *TemporalProvider) Configure(ctx context.Context, req provider.Configure
 
 	tflog.Debug(ctx, "Creating Temporal client")
 	tflog.Debug(ctx, "Use TLS? "+strconv.FormatBool(useTLS))
-	client, err := CreateGRPCClient(clientID, clientSecret, tokenURL, audience, scopes, endpoint, insecure, useTLS, certString, keyString, caCerts, serverName)
+	client, err := CreateGRPCClient(clientID, clientSecret, tokenURL, audience, scopes, endpoint, insecure, useTLS, certString, keyString, caCerts, serverName, grpcMetadata)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Temporal API Client",
@@ -371,9 +395,99 @@ func New(version string) func() provider.Provider {
 	}
 }
 
+// metadataPairs flattens a metadata map into the alternating
+// key,value,key,value... slice that metadata.AppendToOutgoingContext expects.
+// Returns nil for empty input so callers can elide the interceptor entirely.
+func metadataPairs(md map[string]string) []string {
+	if len(md) == 0 {
+		return nil
+	}
+	out := make([]string, 0, 2*len(md))
+	for k, v := range md {
+		out = append(out, k, v)
+	}
+	return out
+}
+
+// metadataUnaryInterceptor returns a UnaryClientInterceptor that appends the
+// given metadata to every outgoing call's context, or nil if md is empty.
+func metadataUnaryInterceptor(md map[string]string) grpc.UnaryClientInterceptor {
+	pairs := metadataPairs(md)
+	if pairs == nil {
+		return nil
+	}
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, pairs...)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// metadataStreamInterceptor is the streaming counterpart of
+// metadataUnaryInterceptor. Temporal admin operations are unary today, but
+// future Temporal SDK versions may use streams (long polls); this keeps the
+// metadata applied uniformly.
+func metadataStreamInterceptor(md map[string]string) grpc.StreamClientInterceptor {
+	pairs := metadataPairs(md)
+	if pairs == nil {
+		return nil
+	}
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		ctx = metadata.AppendToOutgoingContext(ctx, pairs...)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+// dialOptionsForMetadata returns gRPC dial options that inject the given
+// metadata on every call (both unary and streaming). Returns nil slice for
+// empty input.
+func dialOptionsForMetadata(md map[string]string) []grpc.DialOption {
+	var opts []grpc.DialOption
+	if u := metadataUnaryInterceptor(md); u != nil {
+		opts = append(opts, grpc.WithChainUnaryInterceptor(u))
+	}
+	if s := metadataStreamInterceptor(md); s != nil {
+		opts = append(opts, grpc.WithChainStreamInterceptor(s))
+	}
+	return opts
+}
+
+// parseGrpcMetadataEnv parses the TEMPORAL_GRPC_METADATA env var. Format:
+// comma-separated `key=value` pairs (e.g.
+// "cf-access-client-id=abc,cf-access-client-secret=def"). Empty values and
+// malformed pairs are silently dropped — provider config takes precedence
+// anyway.
+func parseGrpcMetadataEnv(s string) map[string]string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	out := map[string]string{}
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		eq := strings.Index(p, "=")
+		if eq <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(p[:eq])
+		v := strings.TrimSpace(p[eq+1:])
+		if k != "" && v != "" {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // CreateAuthenticatedClient creates a gRPC client with OAuth authentication.
 // It uses a TokenSource so the token is automatically refreshed when it expires.
-func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL, audience string, scopes []string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
+// Any extraMetadata is appended to every outgoing call alongside the OAuth
+// Authorization header.
+func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL, audience string, scopes []string, credentials grpcCreds.TransportCredentials, extraMetadata map[string]string) (*grpc.ClientConn, error) {
 	cfg := clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -385,30 +499,43 @@ func CreateAuthenticatedClient(endpoint string, clientID, clientSecret, tokenURL
 	}
 	ts := cfg.TokenSource(context.Background())
 
-	return grpc.NewClient(endpoint, grpc.WithTransportCredentials(credentials), grpc.WithUnaryInterceptor(
-		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			token, err := ts.Token()
-			if err != nil {
-				return fmt.Errorf("failed to retrieve OAuth token: %w", err)
-			}
-			newCtx := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token.AccessToken)
-			return invoker(newCtx, method, req, reply, cc, opts...)
-		},
-	))
+	authInterceptor := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		token, err := ts.Token()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve OAuth token: %w", err)
+		}
+		newCtx := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token.AccessToken)
+		return invoker(newCtx, method, req, reply, cc, opts...)
+	}
+
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(credentials),
+		grpc.WithChainUnaryInterceptor(authInterceptor),
+	}
+	dialOpts = append(dialOpts, dialOptionsForMetadata(extraMetadata)...)
+	return grpc.NewClient(endpoint, dialOpts...)
 }
 
 // CreateSecureClient creates a gRPC client using mTLS without OAuth authentication.
-func CreateSecureClient(endpoint string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
-	return grpc.NewClient(endpoint, grpc.WithTransportCredentials(credentials))
+// Any extraMetadata is appended to every outgoing call.
+func CreateSecureClient(endpoint string, credentials grpcCreds.TransportCredentials, extraMetadata map[string]string) (*grpc.ClientConn, error) {
+	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(credentials)}
+	dialOpts = append(dialOpts, dialOptionsForMetadata(extraMetadata)...)
+	return grpc.NewClient(endpoint, dialOpts...)
 }
 
 // CreateInsecureClient creates a gRPC client without any authentication.
-func CreateInsecureClient(endpoint string, credentials grpcCreds.TransportCredentials) (*grpc.ClientConn, error) {
-	return grpc.NewClient(endpoint, grpc.WithTransportCredentials(credentials))
+// Any extraMetadata is appended to every outgoing call (useful when an
+// upstream reverse proxy provides the auth, e.g. Cloudflare Access service
+// tokens, even though this gRPC hop is plaintext).
+func CreateInsecureClient(endpoint string, credentials grpcCreds.TransportCredentials, extraMetadata map[string]string) (*grpc.ClientConn, error) {
+	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(credentials)}
+	dialOpts = append(dialOpts, dialOptionsForMetadata(extraMetadata)...)
+	return grpc.NewClient(endpoint, dialOpts...)
 }
 
 // CreateGRPCClient decides which gRPC client to create based on clientID.
-func CreateGRPCClient(clientID, clientSecret, tokenURL, audience string, scopes []string, endpoint string, insecure bool, useTLS bool, certString string, keyString string, caCerts string, serverName string) (*grpc.ClientConn, error) {
+func CreateGRPCClient(clientID, clientSecret, tokenURL, audience string, scopes []string, endpoint string, insecure bool, useTLS bool, certString string, keyString string, caCerts string, serverName string, grpcMetadata map[string]string) (*grpc.ClientConn, error) {
 	var credentials grpcCreds.TransportCredentials
 
 	switch insecure {
@@ -440,12 +567,12 @@ func CreateGRPCClient(clientID, clientSecret, tokenURL, audience string, scopes 
 	}
 
 	if clientID != "" {
-		return CreateAuthenticatedClient(endpoint, clientID, clientSecret, tokenURL, audience, scopes, credentials)
+		return CreateAuthenticatedClient(endpoint, clientID, clientSecret, tokenURL, audience, scopes, credentials, grpcMetadata)
 	} else if useTLS {
-		return CreateSecureClient(endpoint, credentials)
+		return CreateSecureClient(endpoint, credentials, grpcMetadata)
 	}
 
-	return CreateInsecureClient(endpoint, credentials)
+	return CreateInsecureClient(endpoint, credentials, grpcMetadata)
 }
 
 // Function to get CA certificates.

--- a/internal/provider/provider_metadata_test.go
+++ b/internal/provider/provider_metadata_test.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	grpcInsec "google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// captureMD installs an UnknownServiceHandler that records the incoming
+// metadata of the first request, then signals via done. UnknownServiceHandler
+// runs even when no service is registered for the called method (the
+// alternative, UnaryInterceptor, only fires for registered services and
+// returns Unimplemented before reaching the interceptor for unknown calls).
+func captureMD(t *testing.T, lis net.Listener) (*metadata.MD, chan struct{}) {
+	t.Helper()
+	got := &metadata.MD{}
+	var mu sync.Mutex
+	done := make(chan struct{}, 1)
+
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(
+		func(srv interface{}, stream grpc.ServerStream) error {
+			md, _ := metadata.FromIncomingContext(stream.Context())
+			mu.Lock()
+			*got = md
+			mu.Unlock()
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+			// Return success so the client doesn't see Unimplemented.
+			return nil
+		},
+	))
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return got, done
+}
+
+func mustListen(t *testing.T) net.Listener {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+	return lis
+}
+
+func mdValues(md metadata.MD, key string) []string {
+	v := md.Get(key)
+	sort.Strings(v)
+	return v
+}
+
+func TestMetadata_InsecureClient_AppendsHeaders(t *testing.T) {
+	lis := mustListen(t)
+	got, done := captureMD(t, lis)
+
+	conn, err := CreateInsecureClient(
+		lis.Addr().String(),
+		grpcInsec.NewCredentials(),
+		map[string]string{
+			"cf-access-client-id":     "abc.access",
+			"cf-access-client-secret": "shh",
+		},
+	)
+	if err != nil {
+		t.Fatalf("CreateInsecureClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// UnknownServiceHandler returns success but without a typed response, so
+	// proto unmarshal fails on the client side. We don't care about the
+	// response — only that the request reached the server with our metadata.
+	_ = conn.Invoke(ctx, "/no.svc/Method", &emptypb.Empty{}, &emptypb.Empty{})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received the call")
+	}
+
+	if v := mdValues(*got, "cf-access-client-id"); !reflect.DeepEqual(v, []string{"abc.access"}) {
+		t.Errorf("cf-access-client-id = %v, want [abc.access]", v)
+	}
+	if v := mdValues(*got, "cf-access-client-secret"); !reflect.DeepEqual(v, []string{"shh"}) {
+		t.Errorf("cf-access-client-secret = %v, want [shh]", v)
+	}
+}
+
+func TestMetadata_NilMap_OmitsInterceptor(t *testing.T) {
+	// The whole point of returning nil from metadataUnaryInterceptor when md
+	// is empty is to avoid a no-op interceptor in the dial chain. Verify
+	// that dialOptionsForMetadata returns an empty slice for nil/empty maps.
+	for name, in := range map[string]map[string]string{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := dialOptionsForMetadata(in); len(got) != 0 {
+				t.Errorf("dialOptionsForMetadata(%v) = %d opts, want 0", in, len(got))
+			}
+		})
+	}
+}
+
+func TestParseGrpcMetadataEnv(t *testing.T) {
+	cases := map[string]struct {
+		in   string
+		want map[string]string
+	}{
+		"empty":          {"", nil},
+		"single":         {"k=v", map[string]string{"k": "v"}},
+		"two":            {"a=1,b=2", map[string]string{"a": "1", "b": "2"}},
+		"surrounding ws": {"  k = v  ,  m = n  ", map[string]string{"k": "v", "m": "n"}},
+		"missing eq":     {"a=1,nope,b=2", map[string]string{"a": "1", "b": "2"}},
+		"empty key":      {"=v,b=2", map[string]string{"b": "2"}},
+		"empty value":    {"a=,b=2", map[string]string{"b": "2"}},
+		"all garbage":    {",,,", nil},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := parseGrpcMetadataEnv(c.in); !reflect.DeepEqual(got, c.want) {
+				t.Errorf("parseGrpcMetadataEnv(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMetadata_AuthenticatedClient_AppendsBothBearerAndExtras(t *testing.T) {
+	// Mirror the OAuth test pattern: a mock token endpoint and a stub gRPC
+	// server that captures the incoming metadata. Verify the OAuth Bearer
+	// header AND the extra metadata both arrive.
+	lis := mustListen(t)
+	got, done := captureMD(t, lis)
+
+	calls := 0
+	tokSrv := newMockTokenServer(t, &calls, 3600)
+	defer tokSrv.Close()
+
+	conn, err := CreateAuthenticatedClient(
+		lis.Addr().String(),
+		"client-id",
+		"client-secret",
+		tokSrv.URL+"/token",
+		"audience",
+		[]string{"scope"},
+		grpcInsec.NewCredentials(),
+		map[string]string{"cf-access-client-id": "abc.access"},
+	)
+	if err != nil {
+		t.Fatalf("CreateAuthenticatedClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	// UnknownServiceHandler returns success but without a typed response, so
+	// proto unmarshal fails on the client side. We don't care about the
+	// response — only that the request reached the server with our metadata.
+	_ = conn.Invoke(ctx, "/no.svc/Method", &emptypb.Empty{}, &emptypb.Empty{})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received the call")
+	}
+
+	if v := (*got).Get("authorization"); len(v) != 1 || v[0] == "" {
+		t.Errorf("authorization header missing, got %v", v)
+	}
+	if v := mdValues(*got, "cf-access-client-id"); !reflect.DeepEqual(v, []string{"abc.access"}) {
+		t.Errorf("cf-access-client-id = %v, want [abc.access]", v)
+	}
+}

--- a/internal/provider/provider_oauth_test.go
+++ b/internal/provider/provider_oauth_test.go
@@ -50,6 +50,7 @@ func TestCreateAuthenticatedClient_LazyTokenFetch(t *testing.T) {
 		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
@@ -70,6 +71,7 @@ func TestCreateAuthenticatedClient_TokenServerUnreachable(t *testing.T) {
 		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient must not fail at construction when token server is unreachable: %v", err)
@@ -90,6 +92,7 @@ func TestCreateAuthenticatedClient_RefreshesExpiredToken(t *testing.T) {
 		"test-audience",
 		[]string{"scope"},
 		grpcInsec.NewCredentials(),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient returned error: %v", err)
@@ -147,6 +150,7 @@ func TestCreateAuthenticatedClient_PassesAudienceInTokenRequest(t *testing.T) {
 		wantAudience,
 		wantScopes,
 		grpcInsec.NewCredentials(),
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateAuthenticatedClient: %v", err)
@@ -219,6 +223,7 @@ func TestCreateGRPCClient_DoesNotReflectAudienceIntoScopes(t *testing.T) {
 		true,
 		false,
 		"", "", "", "",
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateGRPCClient: %v", err)


### PR DESCRIPTION
Disclaimer: written by AI, but reviewed by me and currently running in my home lab setup.

## What

Adds a new optional `grpc_metadata` map to the provider config that gets appended as static gRPC metadata (HTTP/2 headers on the wire) on every outgoing call.

```hcl
provider "temporal" {
  host = "temporal-grpc.example.com"
  port = "443"
  grpc_metadata = {
    "cf-access-client-id"     = "abc.access"
    "cf-access-client-secret" = "shh"
  }
}
```

Also reads `TEMPORAL_GRPC_METADATA` (comma-separated `k=v` pairs) for parity with the existing env-var pattern.

## Why

Useful for reverse-proxy authentication that lives at the HTTP/2 header layer rather than the OAuth Bearer layer:

- **Cloudflare Access service tokens** (`cf-access-client-id` / `cf-access-client-secret`) — the original motivation. CF Access can't gate gRPC on most plans, so users front Temporal with their own reverse proxy that validates a header
- **caddy-security with API keys** (`x-api-key` / `x-auth-realm`)
- **AWS WAF custom-rule headers**
- **Tailscale Funnel headers**
- **Internal mTLS proxies** that translate certs to a header for the backend

The provider already supports OAuth Bearer (via `client_id`/`client_secret`/`token_url`) but that's only one shape of header auth. For everything else, users currently have to set up SSH tunnels or `cloudflared access tcp` wrappers — fine for ad-hoc, painful as a documented pattern.

## Implementation

- New `temporalProviderModel.GrpcMetadata` (`types.Map`) with `tfsdk:"grpc_metadata"`. Schema marks `Sensitive=true` (typical use is credentials).
- `Configure()` reads the map AND the `TEMPORAL_GRPC_METADATA` env var; provider config takes precedence (mirrors the existing pattern for other attrs).
- `CreateGRPCClient` takes the metadata as a new trailing arg; threads through to all three constructors (`Authenticated`, `Secure`, `Insecure`).
- Each constructor adds matching `grpc.WithChainUnaryInterceptor` and `grpc.WithChainStreamInterceptor` that call `metadata.AppendToOutgoingContext` per RPC. Returns nil interceptor for empty/nil metadata so we don't add a no-op to the dial chain.
- For `CreateAuthenticatedClient`, the existing OAuth Bearer interceptor chains with the new metadata interceptor via `WithChainUnaryInterceptor`, so both the Authorization header AND the extra metadata land on every call.

## Tests

- Existing `provider_oauth_test.go` call sites updated to pass `nil` for the new arg.
- New `provider_metadata_test.go` covers:
  - Insecure client appends configured headers
  - Authenticated client appends BOTH OAuth Bearer AND extras
  - Empty/nil metadata produces no dial options (no no-op interceptor)
  - `parseGrpcMetadataEnv` handles whitespace, missing eq, empty keys/values

## Compatibility

Backwards compatible — every existing call site passes `nil` for the new arg and behaves identically. No schema deprecations.

## Verification

Built locally with these changes via `dev_overrides`, deployed against a real CF-Tunnel-fronted Temporal cluster gated by a Caddy reverse-proxy that validates `X-Api-Key` headers (the caddy-security setup). `tofu plan`/`apply` against three `temporal_schedule` resources succeeds end-to-end with the metadata reaching the origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)